### PR TITLE
User Stories 13 & 15 Completed

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -19,4 +19,7 @@ class FavoritesController < ApplicationController
     flash[:notice] = "#{pet.name} has been removed from your favorites list."
     redirect_back(fallback_location: root_path)
   end
+
+  def destroy_all
+    favorites.
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -17,6 +17,6 @@ class FavoritesController < ApplicationController
     favorites.delete_pet(pet.id)
     session[:favorites] = favorites.contents
     flash[:notice] = "#{pet.name} has been removed from your favorites list."
-    redirect_to "/pets/#{pet.id}"
+    redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -21,5 +21,8 @@ class FavoritesController < ApplicationController
   end
 
   def destroy_all
-    favorites.
+    favorites.reset
+    flash[:notice] = "You have no favorited pets."
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -21,4 +21,9 @@ class Favorite
     @contents[id.to_s] = 0
   end
 
+  def reset
+    @contents.map do |id, favorite_count|
+      @contents[id] = 0
+    end
+  end
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -12,4 +12,4 @@
   <% end %>
 <% end %>
 
-<%= button_to "Remove All Favorite Pets", "/favorites", method: :delete %>
+<%= link_to "Remove All Favorite Pets", "/favorites", method: :delete %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -5,8 +5,9 @@
     <section id="favpet-<%= pet.id %>">
       <%= pet.name %></br>
       <%= image_tag(pet.image, size: "200x200") %></br></br>
+      <%= button_to "Remove from Favorites", "/favorites/#{pet.id}", method: :delete %>
     </section>
   <% elsif favorites.contents.empty? %>
-    "There are no favorited pets to display at this time."      
-  <% end %> 
-<% end %> 
+    "There are no favorited pets to display at this time."
+  <% end %>
+<% end %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -11,3 +11,5 @@
     "There are no favorited pets to display at this time."
   <% end %>
 <% end %>
+
+<%= button_to "Remove All Favorite Pets", "/favorites", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,5 @@ Rails.application.routes.draw do
   get '/favorites', to: 'favorites#index'
   patch '/favorites/:pet_id', to: 'favorites#update'
   delete '/favorites/:pet_id', to: 'favorites#destroy'
+  delete '/favorites', to: 'favorites#destroy_all'
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -170,11 +170,11 @@ RSpec.describe "As a visitor,", type: :feature do
 
       visit "/favorites"
 
-      click_button "Remove All Favorite Pets"
+      click_link "Remove All Favorite Pets"
 
 
       expect(current_path).to eq("/favorites")
       expect(page).to have_content("Favorites: 0")
     end
   end
-end 
+end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "As a visitor,", type: :feature do
-  describe "when I add a pet to favorites and go to Favorites Index page" do 
+  describe "when I add a pet to favorites and go to Favorites Index page" do
     it "then I see all pets I've favorited including their name (as link to pet's show page) and image." do
       shelter_1 = Shelter.create(name: "Jordan's Shelter",
                                  address: "123 Fake St.",
-                                 city: "Arvada", 
+                                 city: "Arvada",
                                  state: "CO",
                                  zip: 80003)
 
@@ -38,26 +38,26 @@ RSpec.describe "As a visitor,", type: :feature do
 
       visit "/favorites"
 
-      within "#favpet-#{luna.id}" do 
+      within "#favpet-#{luna.id}" do
         expect(page).to have_content(luna.name)
         expect(page).to have_css("img[src*='#{luna.image}']")
       end
 
-      within "#favpet-#{nova.id}" do 
+      within "#favpet-#{nova.id}" do
         expect(page).to have_content(nova.name)
         expect(page).to have_css("img[src*='#{nova.image}']")
       end
 
       expect(page).to have_no_content(roomba.name)
       expect(page).to have_no_content("There are no favorited pets to display at this time.")
-    end 
-  end 
+    end
+  end
 
-  describe "when I visit the Favorites Index page without favoriting any pets" do 
+  describe "when I visit the Favorites Index page without favoriting any pets" do
     it "then I see a message saying there are no pets to display." do
       shelter_1 = Shelter.create(name: "Jordan's Shelter",
                                  address: "123 Fake St.",
-                                 city: "Arvada", 
+                                 city: "Arvada",
                                  state: "CO",
                                  zip: 80003)
 
@@ -84,7 +84,52 @@ RSpec.describe "As a visitor,", type: :feature do
 
       visit "/favorites"
 
-      expect(page).to have_content("There are no favorited pets to display at this time.")     
+      expect(page).to have_content("There are no favorited pets to display at this time.")
     end
   end
-end 
+
+  describe "when I visit the Favorites Index page" do
+    it "then I see a button next to each favorited pet allowing me to remove the pet from my favorites." do
+
+      shelter_1 = Shelter.create(name: "Jordan's Shelter",
+                                 address: "123 Fake St.",
+                                 city: "Arvada",
+                                 state: "CO",
+                                 zip: 80003)
+
+      luna = Pet.create(name: "Luna",
+                        age: "5",
+                        sex: "Female",
+                        status: "Adoptable",
+                        image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg",
+                        shelter: shelter_1)
+
+      nova = Pet.create(name: "Nova",
+                        age: "10",
+                        sex: "Female",
+                        status: "Adoptable",
+                        image: "http://cdn.akc.org/content/article-body-image/border_collie_dog_pictures_.jpg",
+                        shelter: shelter_1)
+
+      roomba = Pet.create(name: "Roomba",
+                        age: "7",
+                        sex: "Male",
+                        status: "Pending Adoption",
+                        image: "http://cdn.akc.org/content/article-body-image/basset_hound_dog_pictures_.jpg",
+                        shelter: shelter_1)
+
+      visit "/pets/#{luna.id}"
+      click_button "Add to Favorites"
+
+      visit "/favorites"
+
+      within "#favpet-#{luna.id}" do
+      click_button "Remove from Favorites"
+      end 
+
+      expect(current_path).to eq("/favorites")
+      expect(page).to have_content("Favorites: 0")
+    end
+  end
+
+end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -125,11 +125,56 @@ RSpec.describe "As a visitor,", type: :feature do
 
       within "#favpet-#{luna.id}" do
       click_button "Remove from Favorites"
-      end 
+      end
 
       expect(current_path).to eq("/favorites")
       expect(page).to have_content("Favorites: 0")
     end
   end
 
-end
+  describe "when I visit the Favorites Index page" do
+    it "then I can remove all of favorited pets at once." do
+
+      shelter_1 = Shelter.create(name: "Jordan's Shelter",
+                                 address: "123 Fake St.",
+                                 city: "Arvada",
+                                 state: "CO",
+                                 zip: 80003)
+
+      luna = Pet.create(name: "Luna",
+                        age: "5",
+                        sex: "Female",
+                        status: "Adoptable",
+                        image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg",
+                        shelter: shelter_1)
+
+      nova = Pet.create(name: "Nova",
+                        age: "10",
+                        sex: "Female",
+                        status: "Adoptable",
+                        image: "http://cdn.akc.org/content/article-body-image/border_collie_dog_pictures_.jpg",
+                        shelter: shelter_1)
+
+      roomba = Pet.create(name: "Roomba",
+                        age: "7",
+                        sex: "Male",
+                        status: "Pending Adoption",
+                        image: "http://cdn.akc.org/content/article-body-image/basset_hound_dog_pictures_.jpg",
+                        shelter: shelter_1)
+
+      visit "/pets/#{luna.id}"
+      click_button "Add to Favorites"
+
+      visit "/pets/#{roomba.id}"
+      click_button "Add to Favorites"
+
+      visit "/favorites"
+
+      click_button "Remove All Favorite Pets"
+
+
+      expect(current_path).to eq("/favorites")
+      expect(page).to have_content("Favorites: 0")
+    end
+  end
+end 

--- a/spec/models/favorites_spec.rb
+++ b/spec/models/favorites_spec.rb
@@ -49,13 +49,26 @@ RSpec.describe Favorite do
 
     expect(favorites.contents).to eq({'1' => 0, '2' => 0})
     end
-  end 
+  end
 
   describe "#count_of" do
-  it "returns the count of all pets in the favorites" do
+    it "returns the count of all pets in the favorites" do
     favorites = Favorite.new({})
 
     expect(favorites.count_of(5)).to eq(0)
+    end
   end
-end
+
+  describe "#reset" do
+    it "removes all pets from favorites and sets the nav counter to 0" do
+    favorites = Favorite.new({
+      '1' => 1,
+      '2' => 1
+      })
+
+    favorites.reset
+    expect(favorites.contents).to eq({'1' => 0, '2' => 0})
+    end
+  end
+
 end


### PR DESCRIPTION
Added functionality on Favorites Index Page, including:

- Button next to each favorited pet to remove the pet from favorites and redirect back to the Favorites Index page

- Link at the bottom of the page to remove all pets from favorites list.
(in refactor, we should try to figure out a way to dry up our routes if, possible. I had to create a 'destroy_all' action in the  'delete '/favorites', to: 'favorites#destroy_all' route to differentiate it from the regular #destroy action.)