### PR TITLE
User Stories 27 & 28 Complete

### DIFF
--- a/app/controllers/index.html
+++ b/app/controllers/index.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+    <title>5280 Landmarks</title>
+    <link rel="stylesheet" href="stylesheets/reset.css" title="text/css" />
+    <link rel="stylesheet" href="stylesheets/main.css" title="text/css" />
+  </head>
+  <body>
+    <h1>5280 Landmarks</h1>
+    <img src="images/1.jpg" alt="Denver Art Museum">
+    <h2>Denver Art Museum</h2>
+    <p>Lorem ipsum dolor sit amet, quis idque munere est ex.
+      Eos id soluta meliore menandri, sed ex graeci prompta sapientem.
+      Cum in verterem partiendo, quod partiendo principes vix et. Ne eam virtute abhorreant.
+      At qui doming nemore mediocritatem, ei pri bonorum blandit, vim elitr recusabo salutatus eu.</p>
+    <p>Mea adhuc persecuti in, dolorum mentitum ullamcorper his ut. Graeci scriptorem cum ea, an ignota signiferumque nec.
+      No dicunt sanctus moderatius sed, meliore inermis ei mea. Utinam impedit maiestatis sea ad, quis efficiendi eu mel, ea solet placerat phaedrum vis.
+      Et vix causae aliquam, commodo blandit imperdiet ex his.</p>
+    <p>Duo an eleifend omittantur, te sint civibus recusabo eos. An ius corpora definiebas cotidieque.
+      Eu pri reque sapientem contentiones, fierent conclusionemque mei in. Saepe veniam ne mei, ut facilisi omittantur nec.</p>
+    <p>Nam ad quas consul salutandi, sea ad verterem quaestio. Mei ea quot dictas. Eam choro eloquentiam eu, vim cu facete scriptorem. Mel at latine veritus.</p>
+    <footer>Alia utinam maiorum pro te, eum ex sonet putent discere. Mea cu possit forensibus comprehensam. Mel te primis commodo, nibh labore nostrum ei mel.
+      Ex vix adolescens suscipiantur, malorum iuvaret usu id. At mea lobortis pertinacia, scripta sententiae et mei, sumo partem pro ex.
+      Nam movet facete ex, eos rebum nulla qualisque ea, vis malis clita efficiantur ut. At vel lorem paulo soluta, ancillae quaestio no quo, id vim blandit voluptatum.</footer>
+  </body>
+</html>

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -31,7 +31,10 @@ class SheltersController < ApplicationController
     shelter = Shelter.find(params[:shelter_id])
     shelter.pets.each do |pet|
       pet.destroy
-    end   
+    end
+    shelter.reviews.each do |review|
+      review.destroy
+    end
     Shelter.destroy(params[:shelter_id])
     redirect_to "/shelters"
   end

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -28,6 +28,10 @@ class SheltersController < ApplicationController
   end
 
   def destroy
+    shelter = Shelter.find(params[:shelter_id])
+    shelter.pets.each do |pet|
+      pet.destroy
+    end   
     Shelter.destroy(params[:shelter_id])
     redirect_to "/shelters"
   end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,6 +1,17 @@
-class Shelter < ApplicationRecord 
+class Shelter < ApplicationRecord
   validates_presence_of :name, :address, :city, :state, :zip
 
   has_many :pets
   has_many :reviews, dependent: :destroy
-end 
+
+  def count_approved_applications
+    approved_applications = 0
+    self.pets.each do |pet|
+      if pet.approved_application != nil
+        approved_applications += 1
+      end
+    end
+    approved_applications
+  end
+
+end

--- a/app/views/pet_applications/index.html.erb
+++ b/app/views/pet_applications/index.html.erb
@@ -1,0 +1,9 @@
+<h2><%= @pet.name.upcase %>'S ADOPTION APPLICANTS</h2>
+
+<% if @pet.applications.count > 0 %>
+  <% @pet.applications.each do |application| %>
+   <%= link_to application.name, "/applications/#{application.id}" %></br>
+  <% end %>
+<% else %>
+  There are no applications for this pet, yet.
+<%end %>

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -5,7 +5,9 @@
     <section id="shelter-<%= shelter.id %>">
       <h3><%= link_to shelter.name, "/shelters/#{shelter.id}" %></h3>
       <%= link_to "Update Shelter", "/shelters/#{shelter.id}/edit" %></br>
+      <% if shelter.count_approved_applications == 0 %>
       <%= link_to "Delete Shelter", "/shelters/#{shelter.id}", method: :delete %></br></br>
+      <% end %>
     </section>
   </div>
 <% end %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -38,5 +38,7 @@
     <h4><%= link_to "Add New Review", "/shelters/#{@shelter.id}/reviews/new"%></h4>
     <h4><%= link_to "This Shelter's Pets Page", "/shelters/#{@shelter.id}/pets"%></h4>
     <h4><%= link_to "Update Shelter", "/shelters/#{@shelter.id}/edit"%></h4>
+    <% if @shelter.count_approved_applications == 0 %>
     <h4><%= link_to "Delete Shelter", "/shelters/#{@shelter.id}", method: :delete %></h4>
+    <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,8 +42,6 @@ Rails.application.routes.draw do
   post '/applications', to: 'applications#create'
   get '/applications/:application_id', to: 'applications#show'
 
-
-
   #pet applications
   get '/pets/:pet_id/applications', to: 'pet_applications#show'
   patch '/pets/:pet_id/:application_id', to: 'pet_applications#update'

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -154,3 +154,35 @@ RSpec.describe "As a visitor", type: :feature do
   end
 end
 end
+
+RSpec.describe "As a visitor", type: :feature do
+  it "when I delete a shelter, all of it's reviews are deleted, too" do
+
+    shelter_1 = Shelter.create(name: "Jordan's Shelter",
+                               address: "123 Fake St.",
+                               city: "Arvada",
+                               state: "CO",
+                               zip: 80003)
+
+    luna = Pet.create(name: "Luna",
+                     age: "5",
+                     sex: "Female",
+                     status: "Adoptable",
+                     image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg",
+                     shelter: shelter_1)
+    review_1 = shelter_1.reviews.create(title: "Found my new best friend!",
+                                   rating: 5,
+                                   content: "Staff were so helpful and the process was easy.")
+    review_2 = shelter_1.reviews.create(title: "Good experience",
+                                   rating: 4,
+                                   content: "Happy with this animal shelter",
+                                   image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg")
+
+    visit "/shelters/#{shelter_1.id}"
+    expect(Review.all.length).to eql(2)
+
+    click_on "Delete Shelter"
+    expect(Review.all.length).to eql(0)
+
+  end
+end

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -163,6 +163,11 @@ RSpec.describe "As a visitor", type: :feature do
                                city: "Arvada",
                                state: "CO",
                                zip: 80003)
+    shelter_2 = Shelter.create(name: "Hilary's Shelter",
+                             address: "321 Real Rd.",
+                             city: "Denver",
+                             state: "CO",
+                             zip: 80301)
 
     luna = Pet.create(name: "Luna",
                      age: "5",
@@ -177,12 +182,15 @@ RSpec.describe "As a visitor", type: :feature do
                                    rating: 4,
                                    content: "Happy with this animal shelter",
                                    image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg")
+    review_3 = shelter_2.reviews.create(title: "Okay experience",
+                                  rating: 3,
+                                  content: "Meh")
 
     visit "/shelters/#{shelter_1.id}"
-    expect(Review.all.length).to eql(2)
+    expect(Review.all.length).to eq(3)
 
     click_on "Delete Shelter"
-    expect(Review.all.length).to eql(0)
+    expect(Review.all.length).to eq(1)
 
   end
 end

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -102,3 +102,55 @@ RSpec.describe "As a visitor", type: :feature do
 
   end
 end
+
+RSpec.describe "As a visitor", type: :feature do
+  describe "as long as a shelter doesn't have any pets with a pending status, I can delete the shelter" do
+    it "and when the shelter is deleted, all of its pets are deleted, too" do
+
+    shelter_1 = Shelter.create(name: "Jordan's Shelter",
+                               address: "123 Fake St.",
+                               city: "Arvada",
+                               state: "CO",
+                               zip: 80003)
+
+    shelter_2 = Shelter.create(name: "Hilary's Shelter",
+                              address: "321 Real Rd.",
+                              city: "Denver",
+                              state: "CO",
+                              zip: 80301)
+
+    luna = Pet.create(name: "Luna",
+                     age: "5",
+                     sex: "Female",
+                     status: "Adoptable",
+                     image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg",
+                     shelter: shelter_1)
+
+    roomba = Pet.create(name: "Roomba",
+                     age: "7",
+                     sex: "Male",
+                     status: "Adoptable",
+                     image: "http://cdn.akc.org/content/article-body-image/basset_hound_dog_pictures_.jpg",
+                     shelter: shelter_1)
+
+    sparky = Pet.create(name: "Sparky",
+                    age: "2",
+                    sex: "Male",
+                    status: "Adoptable",
+                    image: "http://cdn.akc.org/content/article-body-image/border_collie_dog_pictures_.jpg",
+                    shelter: shelter_2)
+
+
+
+    visit "/shelters/#{shelter_1.id}"
+
+    click_on "Delete Shelter"
+
+    visit "/pets"
+
+    expect(page).to_not have_content(luna.name)
+    expect(page).to_not have_content(roomba.name)
+    expect(page).to have_content(sparky.name)
+  end
+end
+end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Shelter, type: :model do
-  describe "validations" do 
+  describe "validations" do
     it {should validate_presence_of :name}
     it {should validate_presence_of :address}
     it {should validate_presence_of :city}
@@ -9,8 +9,53 @@ describe Shelter, type: :model do
     it {should validate_presence_of :zip}
   end
 
-  describe "relationships" do 
+  describe "relationships" do
     it {should have_many :pets}
     it {should have_many :reviews}
+  end
+
+  describe "#approved_applications?" do
+    it "returns a boolean value of whether or not any pets in the shelter have an approved application" do
+      shelter_1 = Shelter.create(name: "Jordan's Shelter",
+                                 address: "123 Fake St.",
+                                 city: "Arvada",
+                                 state: "CO",
+                                 zip: 80003)
+
+      luna = Pet.create(name: "Luna",
+                        age: "5",
+                        sex: "Female",
+                        status: "Adoptable",
+                        image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg",
+                        shelter: shelter_1)
+
+      nova = Pet.create(name: "Nova",
+                        age: "10",
+                        sex: "Female",
+                        status: "Adoptable",
+                        image: "http://cdn.akc.org/content/article-body-image/border_collie_dog_pictures_.jpg",
+                        shelter: shelter_1)
+      application = Application.create(name: "name",
+                                       address: "address",
+                                       city: "city",
+                                       state: "state",
+                                       zip: "zip",
+                                       phone_number: "phone_number",
+                                       description: "description")
+      luna = ApplicationPet.create(application_id: application.id, pet_id: luna.id)
+      nova = ApplicationPet.create(application_id: application.id, pet_id: nova.id)
+
+      expect(shelter_1.count_approved_applications).to eq(0)
+
+      # luna = Pet.update(name: "Luna",
+      #                   age: "5",
+      #                   sex: "Female",
+      #                   status: "Adoptable",
+      #                   image: "http://cdn.akc.org/content/article-body-image/norwegianelkhoundpuppy_dog_pictures.jpg",
+      #                   shelter: shelter_1,
+      #                   approved_application: application.id
+      #                   )
+      # expect(shelter_1.count_approved_applications).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
When deleting a shelter (only if there are no pending applications, per user story 26), all pets should also be deleted from the shelter.

Updated shelters_controller destroy action to delete each pet from the shelter before deleting itself. Tested edge case to make sure only pets from that shelter are deleted, not all pets.

When deleting a shelter, all reviews should also be deleted from the shelter.

Updated shelters_controller destroy action to delete each review from the shelter before deleting itself. Tested edge case to make sure only reviews from the associated shelter are deleted, not all reviews.